### PR TITLE
fix: 修复严格别名问题和 position() 返回值

### DIFF
--- a/ByteBuffer.h
+++ b/ByteBuffer.h
@@ -349,6 +349,7 @@ public:
     ByteBuffer& position(uint32_t newPosition)
     {
         position_ = newPosition;
+        return *this;
     }
 
     void printInfo() const
@@ -367,7 +368,9 @@ private:
         if (!p_buffer_ || index + sizeof(T) > limit_)
             return 0;
 
-        return *((T*)&p_buffer_[index]);
+        T data;
+        std::memcpy(&data, &p_buffer_[index], sizeof(T));
+        return data;
     }
 
     template <typename T>


### PR DESCRIPTION
## 描述
本 PR 修复了 Code Review 中发现的两个严重问题。

## 变更内容

### 1. 修复严格别名问题 (Issue #6)
**问题：** `read<T>(index)` 方法通过指针类型转换访问内存，违反 C++ strict aliasing 规则，可能导致未定义行为。

**修改前：**
```cpp
template <typename T>
T read(uint32_t index) const
{
    if (!p_buffer_ || index + sizeof(T) > limit_)
        return 0;

    return *((T*)&p_buffer_[index]);  // ⚠️ 违反严格别名规则
}
```

**修改后：**
```cpp
template <typename T>
T read(uint32_t index) const
{
    if (!p_buffer_ || index + sizeof(T) > limit_)
        return 0;

    T data;
    std::memcpy(&data, &p_buffer_[index], sizeof(T));
    return data;
}
```

### 2. 修复 position() 方法缺少返回值
**问题：** `position(uint32_t)` 方法声明返回 `ByteBuffer&` 但缺少 `return *this;`

**修改前：**
```cpp
ByteBuffer& position(uint32_t newPosition)
{
    position_ = newPosition;
    // ⚠️ 缺少 return *this;
}
```

**修改后：**
```cpp
ByteBuffer& position(uint32_t newPosition)
{
    position_ = newPosition;
    return *this;
}
```

## 影响
- 避免潜在的未定义行为
- 修复编译警告
- 支持链式调用 `position()` 方法
